### PR TITLE
WIP: Webform Handler

### DIFF
--- a/README
+++ b/README
@@ -5,13 +5,18 @@
 
 ## Usage
 1. Create a webform
-2. Add a Price element
-3. Setup the values of the element
-   1. Use the price next to the values to simulate product variations
-   2. Use the price below to create multiple products with one price
-4. Save the webform and create a submission
+2. Add elements
+   1. Order ID (int)
+   2. Order Url (url)
+   3. Order status (string)
+   4. Product (options)
+3. Set permissions for 'Order *'-fields for only administrators.
+4. Setup the values of the element Price
+   1. Use the key to the option values to simulate product variations
+   2. Use the top price below to create multiple products with one price
+5. Setup the Webform Product Handler and map the fields
+6. Create a link-field (no title) in the Order Type 'Webform' called 'field_link_order_origin'.
+7. Save the webform and create a submission
 
 ## Known issues
-* Will only work for the default store, if no store is selected as default, it will crash
-* There is no reference to the webform submission in the order
-* There is no reference to the order in the webform submission
+Still work in progress, please report issues at https://github.com/chx/webform_product/issues

--- a/config/install/commerce_order.commerce_order_item_type.webform.yml
+++ b/config/install/commerce_order.commerce_order_item_type.webform.yml
@@ -6,3 +6,4 @@ id: webform
 purchasableEntityType: ''
 orderType: default
 traits: {  }
+locked: false

--- a/src/Controller/WebformProductController.php
+++ b/src/Controller/WebformProductController.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Drupal\webform_product\Controller;
+
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\Component\Utility\Xss;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Messenger\MessengerTrait;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\webform\WebformInterface;
+use Drupal\webform\WebformSubmissionInterface;
+use Drupal\webform_product\Plugin\WebformHandler\WebformProductWebformHandler;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+/**
+ * Provides route responses for webform product.
+ *
+ * @todo Dependency injection.
+ */
+class WebformProductController extends ControllerBase implements ContainerInjectionInterface {
+
+  use MessengerTrait;
+
+  // Payment statuses.
+  const PAYMENT_STATUS_NULL = '';
+  const PAYMENT_STATUS_INITIALIZED = 'initialized';
+  const PAYMENT_STATUS_CANCELED = 'canceled';
+  const PAYMENT_STATUS_COMPLETED = 'completed';
+  const PAYMENT_STATUS_EXCEPTION = 'exception';
+
+  /**
+   * Complete the submission and order.
+   *
+   * @param \Drupal\webform\WebformInterface $webform
+   *   A webform.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function completedSubmission(WebformInterface $webform) {
+    $webform_submission = $this->getWebformSubmissionFromToken($webform);
+    $order = $this->getOrder();
+
+    $this->checkAccess($webform_submission, $order);
+
+    // Set webform submission to 'completed'.
+    self::setSubmissionOrderStatus($webform_submission, self::PAYMENT_STATUS_COMPLETED);
+
+    $webform_submission
+      ->set('in_draft', FALSE)
+      ->save();
+
+    // Set order to 'completed'.
+    $this->finalizeOrder($order);
+
+    // Load confirmation page settings.
+    $confirmation_type = $webform_submission->getWebform()->getSetting('confirmation_type');
+    $has_confirmation_url = in_array($confirmation_type, [WebformInterface::CONFIRMATION_URL, WebformInterface::CONFIRMATION_URL_MESSAGE]);
+    $has_confirmation_message = !in_array($confirmation_type, [WebformInterface::CONFIRMATION_URL]);
+
+    $redirect_url = (string) $webform_submission->getSourceUrl()->toString();
+    if ($has_confirmation_url) {
+      // @todo Validate url like \Drupal\webform\WebformSubmissionForm::setConfirmation().
+      $url = $webform_submission->getWebform()->getSetting('confirmation_url');
+      if ($url) {
+        $redirect_url = $url;
+      }
+    }
+
+    if ($has_confirmation_message) {
+      $message = $webform_submission->getWebform()->getSetting('confirmation_message');
+      $this->messenger()->addStatus(Xss::filter($message));
+    }
+
+    $this->redirectToUrl($redirect_url);
+  }
+
+  /**
+   * Cancel the submission and notify user.
+   *
+   * @param \Drupal\webform\WebformInterface $webform
+   *   A webform.
+   */
+  public function canceledSubmission(WebformInterface $webform) {
+    $webform_submission = $this->getWebformSubmissionFromToken($webform);
+
+    self::setSubmissionOrderStatus($webform_submission, self::PAYMENT_STATUS_CANCELED);
+    $webform_submission->resave();
+
+    $this->messenger()->addWarning(t('The payment has been canceled, please re-submit the form to complete the payment.'));
+
+    $url = $webform_submission->getSourceUrl()->toString();
+
+    $this->redirectToUrl($url);
+  }
+
+  /**
+   * Cancel the submission, notify user and log the exception.
+   *
+   * @param \Drupal\webform\WebformInterface $webform
+   *   A webform.
+   */
+  public function exceptionSubmission(WebformInterface $webform) {
+    $webform_submission = $this->getWebformSubmissionFromToken($webform);
+
+    self::setSubmissionOrderStatus($webform_submission, self::PAYMENT_STATUS_EXCEPTION);
+    $webform_submission->resave();
+
+    $this->messenger()->addError(t('Something went wrong, the payment has been canceled. Please try again later.'));
+
+    $url = $webform_submission->getSourceUrl()->toString();
+
+    $this->redirectToUrl($url);
+  }
+
+  /**
+   * Transition the order status to 'completed'.
+   *
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   A order.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function finalizeOrder(OrderInterface $order) {
+    $order->set('state', self::PAYMENT_STATUS_COMPLETED)->save();
+  }
+
+  /**
+   * Get the order from the current request.
+   *
+   * @return \Drupal\commerce_order\Entity\OrderInterface
+   *   A order.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   */
+  protected function getOrder() {
+    $order_id = \Drupal::requestStack()->getCurrentRequest()->get('order');
+    /** @var \Drupal\commerce_order\Entity\OrderInterface $order */
+    $order = \Drupal::entityTypeManager()
+      ->getStorage('commerce_order')
+      ->load($order_id);
+    return $order;
+  }
+
+  /**
+   * Get webform submission from query token.
+   *
+   * @param \Drupal\webform\WebformInterface $webform
+   *   The webform, related to the token.
+   *
+   * @return \Drupal\webform\WebformSubmissionInterface|null
+   *   A submission loaded from the token.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   */
+  protected function getWebformSubmissionFromToken(WebformInterface $webform) {
+    /** @var \Drupal\webform\WebformSubmissionStorageInterface $storage */
+    $storage = \Drupal::entityTypeManager()->getStorage('webform_submission');
+
+    $token = \Drupal::requestStack()->getCurrentRequest()->get('submission');
+    if (!$token) {
+      throw new AccessDeniedHttpException('Token not found.');
+    }
+
+    $webform_submission = $storage->loadFromToken($token, $webform);
+    if (!$webform_submission) {
+      throw new AccessDeniedHttpException('Webform submission failed to load.');
+    }
+
+    return $webform_submission;
+  }
+
+  /**
+   * Check if the submission and order.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $webform_submission
+   *   A webform submission.
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   A order.
+   */
+  protected function checkAccess(WebformSubmissionInterface $webform_submission, OrderInterface $order) {
+    if (!$order || !$webform_submission->isDraft() || $order->getState()->value == 'completed') {
+      throw new AccessDeniedHttpException('Submission already completed.');
+    }
+  }
+
+  /**
+   * Redirect to the given Url.
+   *
+   * @param string $url
+   *   Url to redirect.
+   */
+  protected function redirectToUrl($url) {
+    // Redirect to confirmation page.
+    $response = new TrustedRedirectResponse($url);
+
+    $request = \Drupal::request();
+    // Save the session.
+    $request->getSession()->save();
+    $response->prepare($request);
+    // Trigger kernel events.
+    \Drupal::service('kernel')->terminate($request, $response);
+
+    $response->send();
+  }
+
+  /**
+   * Set the Order status in the Submission.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $webformSubmission
+   *   The webform Submission.
+   * @param string $status
+   *   The status to store in the Submission.
+   */
+  public static function setSubmissionOrderStatus(WebformSubmissionInterface $webformSubmission, $status) {
+    $handlers = $webformSubmission->getWebform()->getHandlers('webform_product');
+
+    $config = $handlers->getConfiguration();
+    /** @var \Drupal\webform\Plugin\WebformHandlerInterface $handler */
+    $handler = reset($config);
+    $settings = $handler['settings'];
+
+    if ($settings[WebformProductWebformHandler::FIELD_STATUS]) {
+      $webformSubmission->setElementData($settings[WebformProductWebformHandler::FIELD_STATUS], $status);
+    }
+  }
+
+}

--- a/src/EventSubscriber/OrderEventSubscriber.php
+++ b/src/EventSubscriber/OrderEventSubscriber.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\webform_product\EventSubscriber;
+
+use Drupal\Core\Logger\LoggerChannelTrait;
+use Drupal\Core\Url;
+use Drupal\state_machine\Event\WorkflowTransitionEvent;
+use Drupal\webform_product\Controller\WebformProductController;
+use Drupal\webform_product\Plugin\WebformHandler\WebformProductWebformHandler;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class OrderEventSubscriber.
+ *
+ * @package Drupal\webform_product\ProductEventSubscriber
+ */
+class OrderEventSubscriber implements EventSubscriberInterface {
+
+  use LoggerChannelTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events = [
+      'commerce_order.validate.post_transition' => ['onOrderValidatePostTransition'],
+    ];
+    return $events;
+  }
+
+  /**
+   * Post Transition; Place (from Draft to Validation).
+   *
+   * Execute Webform Submission Handlers on Validate transition, when a payment
+   * has been validated by the payment provider.
+   *
+   * This will only be triggered if the submission is initialized.
+   *
+   * @todo Add validate state to the submission status field.
+   * @todo Make use of the workflow labels, instead of custom labels.
+   *
+   * @param \Drupal\state_machine\Event\WorkflowTransitionEvent $event
+   *   The event.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function onOrderValidatePostTransition(WorkflowTransitionEvent $event) {
+    $order = $event->getEntity();
+
+    if (!$order->hasField(WebformProductWebformHandler::FIELD_LINK_ORDER_ORIGIN)) {
+      return;
+    }
+
+    $source_uri = $order->get(WebformProductWebformHandler::FIELD_LINK_ORDER_ORIGIN)->getValue();
+    $params = Url::fromUri($source_uri[0]['uri'])->getRouteParameters();
+
+    /** @var \Drupal\webform\WebformSubmissionInterface $webformSubmission */
+    $webformSubmission = \Drupal::entityTypeManager()->getStorage('webform_submission')->load($params['webform_submission']);
+    $handlers = $webformSubmission->getWebform()->getHandlers('webform_product');
+
+    $config = $handlers->getConfiguration();
+    if (!$config) {
+      return;
+    }
+
+    /** @var \Drupal\webform\Plugin\WebformHandlerInterface $handler */
+    $handler = reset($config);
+    $settings = $handler['settings'];
+
+    $status = $webformSubmission->getElementData($settings[WebformProductWebformHandler::FIELD_STATUS]);
+
+    // Complete submission if this hasn't been done.
+    // There is no need for an access check, because the transition will check.
+    if ($status && $status === WebformProductController::PAYMENT_STATUS_INITIALIZED) {
+
+      // Disable the webform draft state, to mark the payment as completed.
+      // Set the webform 'completed' state, to trigger webform handlers such as
+      // Exact and Email.
+      $webformSubmission
+        ->setElementData($settings[WebformProductWebformHandler::FIELD_STATUS], WebformProductController::PAYMENT_STATUS_COMPLETED)
+        ->set('in_draft', FALSE)
+        ->set('completed', TRUE)
+        ->save();
+
+      $this->getLogger('webform_product')->notice('Finalized Webform Submission %sid on payment', [
+        '%sid' => $webformSubmission->id(),
+      ]);
+    }
+  }
+
+}

--- a/src/Plugin/WebformHandler/WebformProductWebformHandler.php
+++ b/src/Plugin/WebformHandler/WebformProductWebformHandler.php
@@ -1,0 +1,607 @@
+<?php
+
+namespace Drupal\webform_product\Plugin\WebformHandler;
+
+use Drupal\commerce_cart\CartProviderInterface;
+use Drupal\commerce_order\Entity\OrderInterface;
+use Drupal\commerce_order\Entity\OrderItem;
+use Drupal\commerce_store\Entity\StoreInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Messenger\MessengerTrait;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Url;
+use Drupal\profile\Entity\Profile;
+use Drupal\webform\Plugin\WebformHandlerBase;
+use Drupal\webform\WebformInterface;
+use Drupal\webform\WebformSubmissionConditionsValidatorInterface;
+use Drupal\webform\WebformSubmissionInterface;
+use Drupal\webform_product\Controller\WebformProductController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Webform submission Commerce Product handler.
+ *
+ * @WebformHandler(
+ *   id = "webform_product",
+ *   label = @Translation("Webform to Commerce Product"),
+ *   category = @Translation("Commerce"),
+ *   description = @Translation("Save submission as a product."),
+ *   cardinality = \Drupal\webform\Plugin\WebformHandlerInterface::CARDINALITY_SINGLE,
+ *   results = \Drupal\webform\Plugin\WebformHandlerInterface::RESULTS_PROCESSED,
+ *   submission = \Drupal\webform\Plugin\WebformHandlerInterface::SUBMISSION_REQUIRED,
+ * )
+ */
+class WebformProductWebformHandler extends WebformHandlerBase {
+
+  use MessengerTrait;
+
+  // Mapped field names.
+  const FIELD_STATUS = 'field_payment_status';
+  const FIELD_METHOD = 'payment_method';
+  const FIELD_ORDER_ID = 'field_order_id';
+  const FIELD_ORDER_URL = 'field_order_url';
+  const FIELD_TOTAL_PRICE = 'field_total_price';
+  const FIELD_GATEWAY = 'payment_gateway';
+  const FIELD_CHECKOUT_STEP = 'checkout_step';
+  const FIELD_ORDER_TYPE = 'order_type';
+  const FIELD_ORDER_ITEM_TYPE = 'order_item_type';
+  const FIELD_STORE = 'store';
+  const FIELD_LINK_ORDER_ORIGIN = 'field_link_order_origin';
+
+  // Mapped field defaults.
+  const DEFAULT_ORDER_TYPE = 'webform';
+  const DEFAULT_ORDER_ITEM_TYPE = 'webform';
+  const DEFAULT_CHECKOUT_STEP = 'payment';
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, LoggerChannelFactoryInterface $logger_factory, ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, WebformSubmissionConditionsValidatorInterface $conditions_validator) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $logger_factory, $config_factory, $entity_type_manager, $conditions_validator);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      self::FIELD_STORE => NULL,
+      self::FIELD_ORDER_TYPE => self::DEFAULT_ORDER_TYPE,
+      self::FIELD_ORDER_ITEM_TYPE => self::DEFAULT_ORDER_ITEM_TYPE,
+      'route' => 'commerce_checkout.form',
+      self::FIELD_CHECKOUT_STEP => self::DEFAULT_CHECKOUT_STEP,
+      self::FIELD_GATEWAY => NULL,
+      self::FIELD_METHOD => NULL,
+      self::FIELD_STATUS => NULL,
+      self::FIELD_ORDER_ID => NULL,
+      self::FIELD_ORDER_URL => NULL,
+      self::FIELD_TOTAL_PRICE => NULL,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @todo Create debug mode setting.
+   * @todo Create field mapping for Billing information (name, address & mail).
+   * @todo Create more route choices.
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $configuration = $this->getConfiguration();
+    $settings = $configuration['settings'];
+
+    $form['commerce'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Commerce'),
+    ];
+    $form['commerce']['store'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Store'),
+      '#options' => $this->getEntityOptions('commerce_store'),
+      '#default_value' => $settings['store'],
+      '#required' => TRUE,
+    ];
+    $form['commerce'][self::FIELD_ORDER_TYPE] = [
+      '#type' => 'select',
+      '#title' => $this->t('Order type'),
+      '#options' => $this->getEntityOptions('commerce_order_type'),
+      '#default_value' => $settings[self::FIELD_ORDER_TYPE],
+      '#required' => TRUE,
+    ];
+    $form['commerce'][self::FIELD_ORDER_ITEM_TYPE] = [
+      '#type' => 'select',
+      '#title' => $this->t('Order item type'),
+      '#options' => $this->getEntityOptions('commerce_order_item_type'),
+      '#default_value' => $settings[self::FIELD_ORDER_ITEM_TYPE],
+      '#required' => TRUE,
+    ];
+    $form['commerce'][self::FIELD_GATEWAY] = [
+      '#type' => 'select',
+      '#title' => $this->t('Payment provider'),
+      '#options' => $this->getEntityOptions('commerce_payment_gateway', [
+        'status' => TRUE,
+      ]),
+      '#default_value' => $settings[self::FIELD_GATEWAY],
+      '#required' => TRUE,
+    ];
+
+    $form['field_mapping'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Field mapping'),
+    ];
+
+    $field_types = ['textfield'];
+    $form['field_mapping'][self::FIELD_STATUS] = [
+      '#type' => 'select',
+      '#title' => $this->t('Payment status'),
+      '#options' => $this->getElementsSelectOptions($field_types),
+      '#default_value' => $settings[self::FIELD_STATUS],
+      '#empty_value' => '',
+      '#required' => TRUE,
+      '#description' => $this->t('Field types allowed: @types.', ['@types' => implode(', ', $field_types)]),
+    ];
+
+    $field_types = ['number', 'numeric', 'textfield'];
+    $form['field_mapping'][self::FIELD_ORDER_ID] = [
+      '#type' => 'select',
+      '#title' => $this->t('Order ID'),
+      '#options' => $this->getElementsSelectOptions($field_types),
+      '#default_value' => $settings[self::FIELD_ORDER_ID],
+      '#empty_value' => '',
+      '#required' => TRUE,
+      '#description' => $this->t('Field types allowed: @types.', ['@types' => implode(', ', $field_types)]),
+    ];
+
+    $field_types = ['url'];
+    $form['field_mapping'][self::FIELD_ORDER_URL] = [
+      '#type' => 'select',
+      '#title' => $this->t('Order URL'),
+      '#options' => $this->getElementsSelectOptions($field_types),
+      '#default_value' => $settings[self::FIELD_ORDER_URL],
+      '#empty_value' => '',
+      '#required' => TRUE,
+      '#description' => $this->t('Field types allowed: @types.', ['@types' => implode(', ', $field_types)]),
+    ];
+
+    $field_types = ['number', 'numeric', 'textfield'];
+    $form['field_mapping'][self::FIELD_TOTAL_PRICE] = [
+      '#type' => 'select',
+      '#title' => $this->t('Total price'),
+      '#options' => $this->getElementsSelectOptions($field_types),
+      '#default_value' => $settings[self::FIELD_TOTAL_PRICE],
+      '#empty_value' => '',
+      '#required' => FALSE,
+      '#description' => $this->t('Field types allowed: @types.', ['@types' => implode(', ', $field_types)]),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @todo Set mapped webform fields to 'private'.
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    parent::submitConfigurationForm($form, $form_state);
+    parent::applyFormStateToConfiguration($form_state);
+
+    $values = $form_state->getValues();
+
+    foreach ($values['commerce'] as $key => $value) {
+      $this->configuration[$key] = $value;
+    }
+
+    foreach ($values['field_mapping'] as $key => $value) {
+      $this->configuration[$key] = $value;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterElements(array &$elements, WebformInterface $webform) {
+    // @todo Move webform_product_form_webform_ui_element_form_alter() to here?
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE) {
+    if ($update == TRUE) {
+      return;
+    }
+
+    try {
+      $orderItems = $this->getOrderItems($webform_submission);
+      if (empty($orderItems)) {
+        return;
+      }
+
+      /** @var \Drupal\commerce_cart\CartProviderInterface $cartProvider */
+      $cartProvider = \Drupal::service('commerce_cart.cart_provider');
+      $cartOrder = $this->getCart($cartProvider, $this->getStore(), TRUE);
+
+      // Fill the Cart.
+      foreach ($orderItems as $orderItem) {
+        $orderItem->save();
+        $cartOrder->addItem($orderItem);
+      }
+      $cartOrder->save();
+      $cartOrder = $this->entityTypeManager->getStorage('commerce_order')->load($cartOrder->id());
+
+      // Save the Cart (Order) with Submission data.
+      $this->setOrderCheckoutProcess($cartOrder);
+      $this->setOrderLinkReference($cartOrder, $webform_submission);
+      $this->setOrderCustomer($cartOrder);
+
+      // Save the submission with Cart data.
+      $this->setSubmissionTotalPrice($webform_submission, $cartOrder);
+      WebformProductController::setSubmissionOrderStatus($webform_submission, WebformProductController::PAYMENT_STATUS_INITIALIZED);
+      $this->setSubmissionOrderReference($webform_submission, $cartOrder);
+      $webform_submission->set('in_draft', TRUE);
+      $webform_submission->resave();
+
+      $cartOrder->save();
+
+      // Reload the order.
+      $cartOrder = $this->entityTypeManager->getStorage('commerce_order')->load($cartOrder->id());
+
+      $this->redirectToCheckout($cartOrder);
+    }
+    catch (\Exception $e) {
+      $this->loggerFactory->get($this->pluginId)->error($e->getMessage());
+    }
+  }
+
+  /**
+   * Get option list of Entities.
+   *
+   * @param string $entity_type
+   *   The entity type to load.
+   * @param array $properties
+   *   The loaded entity condtions.
+   *
+   * @return array
+   *   List with ids as key and label as value.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   */
+  protected function getEntityOptions($entity_type, array $properties = []) {
+    $options = [];
+
+    /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface[] $payment_gateways */
+    $entities = $this->entityTypeManager
+      ->getStorage($entity_type)
+      ->loadByProperties($properties);
+
+    foreach ($entities as $entity) {
+      $options[$entity->id()] = $entity->label();
+    }
+
+    return $options;
+  }
+
+  /**
+   * Gather all Order Items from the webform Submission.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $webformSubmission
+   *   The webform submission.
+   *
+   * @return \Drupal\commerce_order\Entity\OrderItemInterface[]
+   *   List of Order Items.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   */
+  protected function getOrderItems(WebformSubmissionInterface $webformSubmission) {
+    $price_fields = $this->getWebform()->getThirdPartySettings($this->pluginId);
+
+    // No prices, no Order.
+    if (!$price_fields) {
+      return [];
+    }
+
+    $payment_status = $this->getSavedPaymentStatus($webformSubmission);
+
+    // Create only an order for new webform submissions.
+    if ($payment_status != WebformProductController::PAYMENT_STATUS_NULL) {
+      return [];
+    }
+
+    /** @var \Drupal\commerce_store\Entity\StoreInterface $store */
+    $store = $this->getStore();
+    $currencyCode = $store->getDefaultCurrency()->getCurrencyCode();
+
+    $orderItems = [];
+    $elements = $this->getWebform()->getElementsInitializedAndFlattened();
+
+    // Create Order Item for each:
+    // - element option with a price.
+    // - element with a top price.
+    foreach ($webformSubmission->getData() as $key => $value) {
+      if (!isset($price_fields[$key])) {
+        continue;
+      }
+
+      // Element with 'top'.
+      if (!empty($price_fields[$key]['top'])) {
+        $orderItems[] = OrderItem::create([
+          'type' => $this->configuration[self::FIELD_ORDER_ITEM_TYPE],
+          'label' => $elements[$key]['#title'] . ' - ' . $this->getWebform()->label(),
+          'quantity' => 1,
+          'unit_price' => ['number' => $price_fields[$key]['top'], 'currency_code' => $currencyCode],
+        ]);
+      }
+
+      if (!empty($price_fields[$key]['options'])) {
+        // Fix for when value is not an array.
+        if (!is_array($value)) {
+          $value = [$value];
+        }
+
+        // Option elements with price as option (checkboxes or radios).
+        foreach (array_intersect($value, array_keys($price_fields[$key]['options'])) as $option) {
+          $orderItems[] = OrderItem::create([
+            'type' => $this->configuration[self::FIELD_ORDER_ITEM_TYPE],
+            'title' => $elements[$key]['#options'][$option] . ' - ' . $this->getWebform()->label(),
+            'quantity' => 1,
+            'unit_price' => ['number' => $price_fields[$key]['options'][$option], 'currency_code' => $currencyCode],
+          ]);
+        }
+      }
+    }
+
+    return $orderItems;
+  }
+
+  /**
+   * Get webform elements selectors as options.
+   *
+   * @param array $types
+   *   List of types to filter.
+   *   - Leave empty skip filtering of types.
+   *
+   * @see \Drupal\webform\Entity\Webform::getElementsSelectorOptions()
+   *
+   * @return array
+   *   Webform elements selectors as options.
+   */
+  private function getElementsSelectOptions(array $types = []) {
+    $options = [];
+    $elements = $this->getWebform()->getElementsInitializedAndFlattened();
+    foreach ($elements as $key => $element) {
+      // Skip element if not in given 'types' array.
+      if ($types && !in_array($element['#type'], $types)) {
+        continue;
+      }
+
+      $options[$key] = $element['#title'];
+    }
+    return $options;
+  }
+
+  /**
+   * Get the payment status of the submission.
+   *
+   * - Nothing if there isn't any payment at all.
+   * - Initilized for started, but not completed payments.
+   * - Canceled for payments canceled by the user.
+   * - Exception for payments canceled by the provider.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $webformSubmission
+   *   The webform submission.
+   *
+   * @return string
+   *   The status of the payment.
+   *
+   * @see \Drupal\webform_product\Plugin\WebformHandler\WebformProductWebformHandler::PAYMENT_STATUS_NULL;
+   * @see \Drupal\webform_product\Plugin\WebformHandler\WebformProductWebformHandler::PAYMENT_STATUS_INITIALIZED;\
+   * @see \Drupal\webform_product\Plugin\WebformHandler\WebformProductWebformHandler::PAYMENT_STATUS_CANCELED;
+   * @see \Drupal\webform_product\Plugin\WebformHandler\WebformProductWebformHandler::PAYMENT_STATUS_COMPLETED;
+   * @see \Drupal\webform_product\Plugin\WebformHandler\WebformProductWebformHandler::PAYMENT_STATUS_EXCEPTION;
+   */
+  private function getSavedPaymentStatus(WebformSubmissionInterface $webformSubmission) {
+    $value = $webformSubmission->getElementData($this->configuration[self::FIELD_STATUS]);
+
+    return $value;
+  }
+
+  /**
+   * Set total price of the Order in the Submission.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $webformSubmission
+   *   The webform Submission.
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The Order.
+   */
+  protected function setSubmissionTotalPrice(WebformSubmissionInterface $webformSubmission, OrderInterface $order) {
+    // Save Total price of order.
+    if ($this->configuration[self::FIELD_TOTAL_PRICE]) {
+      $total = $order->getTotalPrice()->getNumber();
+      $webformSubmission->setElementData($this->configuration[self::FIELD_TOTAL_PRICE], $total);
+    }
+  }
+
+  /**
+   * Set the Order reference in the webform Submission.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $webformSubmission
+   *   The webform Submission.
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The Order.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  protected function setSubmissionOrderReference(WebformSubmissionInterface $webformSubmission, OrderInterface $order) {
+    // Save order id to the webform for back reference.
+    if ($this->configuration[self::FIELD_ORDER_ID]) {
+      $webformSubmission
+        ->setElementData($this->configuration[self::FIELD_ORDER_ID], $order->id());
+    }
+    if ($this->configuration[self::FIELD_ORDER_URL]) {
+      $order_url = $order->toUrl()->toString();
+      $webformSubmission
+        ->setElementData($this->configuration[self::FIELD_ORDER_URL], $order_url);
+    }
+  }
+
+  /**
+   * Redirect to the configured checkout step in the Checkout Flow.
+   *
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The Order.
+   */
+  protected function redirectToCheckout(OrderInterface $order) {
+    // Redirect to checkout process.
+    $response = new RedirectResponse(Url::fromRoute($this->configuration['route'], [
+      'commerce_order' => $order->id(),
+      'step' => $this->configuration[self::FIELD_CHECKOUT_STEP],
+    ])->toString());
+
+    $request = \Drupal::request();
+    // Save the session.
+    $request->getSession()->save();
+    $response->prepare($request);
+    // Trigger kernel events.
+    \Drupal::service('kernel')->terminate($request, $response);
+
+    $response->send();
+    exit();
+  }
+
+  /**
+   * Set Customer data for Order.
+   *
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The Order.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   *
+   * @todo Create full commerce profile for order with address and mail info.
+   */
+  protected function setOrderCustomer(OrderInterface $order) {
+    $billing_profile = Profile::create([
+      'uid' => 0,
+      'type' => 'customer',
+    ]);
+    $billing_profile->save();
+
+    // Add profile information.
+    $order->setBillingProfile($billing_profile);
+  }
+
+  /**
+   * Save back reference to the webform as link.
+   *
+   * Order info can't be referenced, if the referenced entity doesn't have the
+   * same lifespan.
+   *
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The Order.
+   * @param \Drupal\webform\WebformSubmissionInterface $webformSubmission
+   *   The webform submission.
+   *
+   * @todo Make field FIELD_LINK_ORDER_ORIGIN configurable.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  protected function setOrderLinkReference(OrderInterface $order, WebformSubmissionInterface $webformSubmission) {
+    if ($order->hasField(self::FIELD_LINK_ORDER_ORIGIN)) {
+      $uri = $webformSubmission->toUrl()->toUriString();
+      $order->set(self::FIELD_LINK_ORDER_ORIGIN, $uri);
+    }
+  }
+
+  /**
+   * Set Checkout Process variables for Order.
+   *
+   * @param \Drupal\commerce_order\Entity\OrderInterface $order
+   *   The Order.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   */
+  protected function setOrderCheckoutProcess(OrderInterface $order) {
+    /** @var \Drupal\commerce_payment\Entity\PaymentGatewayInterface $payment_gateway */
+    $payment_gateway = $this->entityTypeManager->getStorage('commerce_payment_gateway')->load($this->configuration[self::FIELD_GATEWAY]);
+
+    if (!$payment_gateway) {
+      $this->loggerFactory->get($this->pluginId)->error(t('Failed to get a Payment Gateway'));
+      return;
+    }
+
+    $payment_method = empty($this->configuration[self::FIELD_METHOD]) ? NULL : $this->configuration[self::FIELD_METHOD];
+
+    // Save additional info to the order to speedup the checkout progress.
+    $order
+      ->set(self::FIELD_CHECKOUT_STEP, $this->configuration[self::FIELD_CHECKOUT_STEP])
+      ->set(self::FIELD_GATEWAY, $payment_gateway->id())
+      ->set(self::FIELD_METHOD, $payment_method);
+  }
+
+  /**
+   * Get a Cart (Order) for the current user.
+   *
+   * Can be a new or existing cart.
+   *
+   * @param \Drupal\commerce_cart\CartProviderInterface $cartProvider
+   *   The Cart Provider.
+   * @param \Drupal\commerce_store\Entity\StoreInterface $store
+   *   The Store.
+   * @param bool $remove_existing_items
+   *   Flag to remove existing items from the Cart.
+   *
+   * @return \Drupal\commerce_order\Entity\OrderInterface|null
+   *   Cart of current user.
+   */
+  protected function getCart(CartProviderInterface $cartProvider, StoreInterface $store, $remove_existing_items = TRUE) {
+    $order_type = $this->configuration[self::FIELD_ORDER_TYPE];
+
+    /** @var \Drupal\commerce_order\Entity\OrderInterface $order */
+    $order = $cartProvider->getCart($order_type, $store) ?: $cartProvider->createCart($order_type, $store);
+
+    if (!$order) {
+      $this->loggerFactory->get($this->pluginId)->error(t('Failed to get a Cart Order'));
+      return NULL;
+    }
+
+    if ($remove_existing_items && $order->hasItems()) {
+      foreach ($order->getItems() as $item) {
+        $order->removeItem($item);
+      }
+    }
+
+    return $order;
+  }
+
+  /**
+   * Get the selected store.
+   *
+   * @return \Drupal\commerce_store\Entity\StoreInterface
+   *   The Store.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   */
+  protected function getStore() {
+    /** @var \Drupal\commerce_store\Entity\StoreInterface $store */
+    $store = $this->entityTypeManager->getStorage('commerce_store')
+      ->load($this->configuration[self::FIELD_STORE]);
+
+    if (!$store) {
+      $this->loggerFactory->get($this->pluginId)->error(t('Failed to get a Store'));
+      return NULL;
+    }
+
+    return $store;
+  }
+
+}

--- a/src/Plugin/webform_product/WebformOptions.php
+++ b/src/Plugin/webform_product/WebformOptions.php
@@ -12,18 +12,19 @@ class WebformOptions {
 
   public static function process(&$element, FormStateInterface $form_state) {
 
-    // Check for price_* elements, skip the check for Option definitions.
-    if (method_exists($form_state->getFormObject(), 'getElement')) {
-      $element_info = $form_state->getFormObject()->getElement();
-
-      // Only change the form of price_* webform elements.
-      if (strpos($element_info['#type'], 'price_', 0) === FALSE) {
-        return $element;
-      }
-    }
-    else {
-      return $element;
-    }
+    //@todo fix this when Price* webform elements are working.
+//    // Check for price_* elements, skip the check for Option definitions.
+//    if (method_exists($form_state->getFormObject(), 'getElement')) {
+//      $element_info = $form_state->getFormObject()->getElement();
+//
+//      // Only change the form of price_* webform elements.
+//      if (strpos($element_info['#type'], 'price_', 0) === FALSE) {
+//        return $element;
+//      }
+//    }
+//    else {
+//      return $element;
+//    }
 
     $element['options']['#element']['price'] = [
       '#type' => 'textfield',
@@ -39,6 +40,7 @@ class WebformOptions {
         }
       }
     }
+
     // WebFormOptions::convertValuesToOptions() destroys our values so do
     // something about that.
     array_unshift($element['#element_validate'], [get_class(), 'convertToSettings']);

--- a/src/WebFormProductFormHelper.php
+++ b/src/WebFormProductFormHelper.php
@@ -4,18 +4,21 @@ namespace Drupal\webform_product;
 
 use Drupal\commerce_order\Entity\OrderItem;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\webform\WebformInterface;
 use Drupal\webform\WebformSubmissionInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class WebFormProductFormHelper {
 
   public static function processElementForm(&$element, FormStateInterface $form_state, &$complete_form) {
     $element_info = $form_state->getFormObject()->getElement();
 
-    // Only change the form of price_* webform elements.
-    if (strpos($element_info['#type'], 'price_', 0) === FALSE) {
-      return $element;
-    }
+    //@todo fix this when Price* webform elements are working.
+//    // Only change the form of price_* webform elements.
+//    if (strpos($element_info['#type'], 'price_', 0) === FALSE) {
+//      return $element;
+//    }
 
     $element['price'] = [
       '#type' => 'textfield',
@@ -24,6 +27,7 @@ class WebFormProductFormHelper {
       '#maxlength' => 20,
       '#default_value' => static::getSetting($form_state, 'top'),
       '#element_validate' => [[get_class(), 'saveTopPrice']],
+      '#description' => t('Use this to add an extra order item to the order, this can be used as a supplement with the options or single without the prices of the options.'),
     ];
     return $element;
   }
@@ -55,60 +59,6 @@ class WebFormProductFormHelper {
     }
   }
 
-  public static function submissionToCart(array &$form, FormStateInterface $form_state) {
-    /** @var \Drupal\webform\WebformSubmissionInterface $submission */
-    $submission = $form_state->getFormObject()->getEntity();
-    if (!$submission instanceof WebformSubmissionInterface) {
-      return;
-    }
-
-    $webform = $submission->getWebform();
-    if (!$prices = $webform->getThirdPartySettings('webform_product')) {
-      return;
-    }
-
-    /** @var \Drupal\commerce_store\Entity\StoreInterface $store */
-    $store = \Drupal::service('commerce_store.current_store')->getStore();
-    $currencyCode = $store->getDefaultCurrency()->getCurrencyCode();
-    /** @var \Drupal\commerce_cart\CartProviderInterface $cartProvider */
-    $cartProvider = \Drupal::service('commerce_cart.cart_provider');
-    /** @var \Drupal\commerce_order\Entity\OrderInterface $cartOrder */
-    $cartOrder = $cartProvider->getCart('default', $store) ?: $cartProvider->createCart('default', $store);
-    $elements = $webform->getElementsInitializedAndFlattened();
-    $prices = $webform->getThirdPartySettings('webform_product');
-    foreach ($submission->getData() as $key => $value) {
-      if (isset($prices[$key])) {
-        if (!empty($prices[$key]['top'])) {
-          $orderItem = OrderItem::create([
-            'type' => 'webform',
-            'title' => $elements[$key]['#title'],
-            'unit_price' => ['number' => $prices[$key]['top'], 'currency_code' => $currencyCode]
-          ]);
-          $orderItem->save();
-          $cartOrder->addItem($orderItem);
-        }
-        if (!empty($prices[$key]['options'])) {
-          // Fix for when value is not an array.
-          if (!is_array($value)) {
-            $value = [$value];
-          }
-
-          foreach (array_intersect($value, array_keys($prices[$key]['options'])) as $option) {
-            $orderItem = OrderItem::create([
-              'type' => 'webform',
-              'title' => $elements[$key]['#options'][$option],
-              'unit_price' => ['number' => $prices[$key]['options'][$option], 'currency_code' => $currencyCode]
-            ]);
-            $orderItem->save();
-            $cartOrder->addItem($orderItem);
-          }
-        }
-      }
-    }
-    $cartOrder->save();
-    $form_state->setRedirect('commerce_cart.page');
-  }
-
   private static function getWebformInFormState(FormStateInterface $form_state) {
     /** @var \Drupal\webform_ui\Form\WebformUiElementEditForm $formObject */
     $formObject = $form_state->getFormObject();
@@ -117,4 +67,5 @@ class WebFormProductFormHelper {
 
     return ($webformObject instanceof WebformInterface) ? $webformObject : NULL;
   }
+
 }

--- a/src/WebformProductPluginManager.php
+++ b/src/WebformProductPluginManager.php
@@ -7,8 +7,16 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 
+/**
+ * Class WebformProductPluginManager.
+ *
+ * @package Drupal\webform_product
+ */
 class WebformProductPluginManager extends DefaultPluginManager {
 
+  /**
+   * {@inheritdoc}
+   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cacheBackend, ModuleHandlerInterface $module_handler, $plugin_interface = NULL, $plugin_definition_annotation_name = 'Drupal\Component\Annotation\Plugin', $additional_annotation_namespaces = []) {
     parent::__construct('Plugin/webform_product', $namespaces, $module_handler, NULL, PluginID::class);
     $this->setCacheBackend($cacheBackend, 'webform_product');

--- a/templates/webform-handler-webform-product-summary.html.twig
+++ b/templates/webform-handler-webform-product-summary.html.twig
@@ -1,0 +1,19 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a summary of a webform action handler.
+ *
+ * Available variables:
+ * - settings: The current configuration for this debug handler.
+ * - handler: The action handler.
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% if settings.store is not null %}<b>{{ 'Store:'|t }}</b> {{ settings.store }}<br />{% endif %}
+{% if settings.order_type %}<b>{{ 'Order type:'|t }}</b> {{ settings.order_type }}<br />{% endif %}
+{% if settings.checkout_step %}<b>{{ 'Checkout step:'|t }}</b> {{ settings.checkout_step }}<br />{% endif %}
+{% if settings.payment_gateway %}<b>{{ 'Payment gateway:'|t }}</b> {{ settings.payment_gateway }}<br />{% endif %}
+{% if settings.payment_method %}<b>{{ 'Payment method:'|t }}</b> {{ settings.payment_method }}<br />{% endif %}
+

--- a/webform_product.info.yml
+++ b/webform_product.info.yml
@@ -3,6 +3,8 @@ type: module
 description: 'Setup a single webform as a product for Commerce.'
 package: Webform
 core: 8.x
+interface translation project: webform_product
+interface translation server pattern: modules/custom/%project/translations/%project.%language.po
 dependencies:
   - 'webform:webform'
   - 'commerce:commerce'

--- a/webform_product.module
+++ b/webform_product.module
@@ -9,6 +9,7 @@ use Drupal\Component\Plugin\Factory\DefaultFactory;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\webform\WebformInterface;
+use Drupal\webform_product\Plugin\WebformHandler\WebformProductWebformHandler;
 use Drupal\webform_product\WebFormProductFormHelper;
 
 /**
@@ -64,12 +65,12 @@ function webform_product_form_commerce_checkout_flow_multistep_default_alter(&$f
   }
 
   $order = $payment->getOrder();
-  if (!$order || !$order->hasField('field_link_order_origin')) {
+  if (!$order || !$order->hasField(WebformProductWebformHandler::FIELD_LINK_ORDER_ORIGIN)) {
     return;
   }
 
   // Load the webform submission from the saved link on the order.
-  $source_uri = $payment->getOrder()->get('field_link_order_origin')->getValue();
+  $source_uri = $payment->getOrder()->get(WebformProductWebformHandler::FIELD_LINK_ORDER_ORIGIN)->getValue();
   $params = Url::fromUri($source_uri[0]['uri'])->getRouteParameters();
 
   /** @var \Drupal\webform\WebformSubmissionInterface $webformSubmission */

--- a/webform_product.module
+++ b/webform_product.module
@@ -1,7 +1,14 @@
 <?php
 
+/**
+ * @file
+ * Hooks and alters for webform_product.
+ */
+
 use Drupal\Component\Plugin\Factory\DefaultFactory;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\webform\WebformInterface;
 use Drupal\webform_product\WebFormProductFormHelper;
 
 /**
@@ -12,7 +19,10 @@ function webform_product_element_info_alter(array &$info) {
   foreach ($definitions as $id => $definition) {
     /** @var \Drupal\Component\Plugin\PluginManagerInterface $pluginManager */
     if (isset($info[$id])) {
-      $info[$id]['#process'][] = [DefaultFactory::getPluginClass($id, $definition), 'process'];
+      $info[$id]['#process'][] = [
+        DefaultFactory::getPluginClass($id, $definition),
+        'process',
+      ];
     }
   }
 }
@@ -25,8 +35,83 @@ function webform_product_form_webform_ui_element_form_alter(&$form, FormStateInt
 }
 
 /**
- * Implements hook_webform_submission_form_alter().
+ * Implements hook_theme().
  */
-function webform_product_webform_submission_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
-  $form['actions']['submit']['#submit'][] = [WebFormProductFormHelper::class, 'submissionToCart'];
+function webform_product_theme() {
+  return [
+    'webform_handler_webform_product_summary' => [
+      'variables' => ['settings' => NULL, 'handler' => NULL],
+    ],
+  ];
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for commerce_checkout_flow_multistep_default.
+ *
+ * @todo Make it work for onsite payments.
+ */
+function webform_product_form_commerce_checkout_flow_multistep_default_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $offsite = NULL;
+  $payment = NULL;
+  if (isset($form['payment_process']['offsite_payment'])) {
+    $offsite = &$form['payment_process']['offsite_payment'];
+    /** @var \Drupal\commerce_payment\Entity\PaymentInterface $payment */
+    $payment = $offsite['#default_value'];
+  }
+
+  if (!$offsite || !$payment) {
+    return;
+  }
+
+  $order = $payment->getOrder();
+  if (!$order || !$order->hasField('field_link_order_origin')) {
+    return;
+  }
+
+  // Load the webform submission from the saved link on the order.
+  $source_uri = $payment->getOrder()->get('field_link_order_origin')->getValue();
+  $params = Url::fromUri($source_uri[0]['uri'])->getRouteParameters();
+
+  /** @var \Drupal\webform\WebformSubmissionInterface $webformSubmission */
+  $webformSubmission = \Drupal::entityTypeManager()->getStorage('webform_submission')->load($params['webform_submission']);
+
+  $options = [
+    'query' => [
+      'submission' => $webformSubmission->getToken(),
+    ],
+    'absolute' => TRUE,
+  ];
+
+  $webform_id = $webformSubmission->getWebform()->id();
+
+  $offsite['#return_url'] = Url::fromRoute('webform_product.payment.completed', ['webform' => $webform_id, 'order' => $order->id()], $options)->toString();
+  $offsite['#cancel_url'] = Url::fromRoute('webform_product.payment.canceled', ['webform' => $webform_id, 'order' => $order->id()], $options)->toString();
+  $offsite['#exception_url'] = Url::fromRoute('webform_product.payment.exception', ['webform' => $webform_id, 'order' => $order->id()], $options)->toString();
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for webform_settings_confirmation_form.
+ *
+ * Remove not implemented confirmation types,
+ * if the webform_product handler is used.
+ */
+function webform_product_form_webform_settings_confirmation_form_alter(&$form, FormStateInterface $form_state) {
+  /** @var \Drupal\webform\WebformInterface $webform */
+  $webform = $form_state->getFormObject()->getEntity();
+
+  $handlers = $webform->getHandlers('webform_product', TRUE);
+  if ($handlers->count() == 0) {
+    return;
+  }
+
+  foreach ($form['confirmation_type']['confirmation_type']['#options'] as $key => $option) {
+    switch ($key) {
+      case WebformInterface::CONFIRMATION_URL:
+      case WebformInterface::CONFIRMATION_URL_MESSAGE:
+        break;
+
+      default:
+        unset($form['confirmation_type']['confirmation_type']['#options'][$key]);
+    }
+  }
 }

--- a/webform_product.routing.yml
+++ b/webform_product.routing.yml
@@ -1,0 +1,20 @@
+webform_product.payment.completed:
+  path: '/webform-product/{webform}/{order}/completed'
+  defaults:
+    _controller: '\Drupal\webform_product\Controller\WebformProductController::completedSubmission'
+  requirements:
+    _access: 'TRUE'
+
+webform_product.payment.canceled:
+  path: '/webform-product/{webform}/{order}/canceled'
+  defaults:
+    _controller: '\Drupal\webform_product\Controller\WebformProductController::canceledSubmission'
+  requirements:
+    _access: 'TRUE'
+
+webform_product.payment.exception:
+  path: '/webform-product/{webform}/{order}/exception'
+  defaults:
+    _controller: '\Drupal\webform_product\Controller\WebformProductController::exceptionSubmission'
+  requirements:
+    _access: 'TRUE'

--- a/webform_product.services.yml
+++ b/webform_product.services.yml
@@ -2,4 +2,3 @@ services:
   plugin.manager.webform_product:
     class: Drupal\webform_product\WebformProductPluginManager
     parent: default_plugin_manager
-

--- a/webform_product.services.yml
+++ b/webform_product.services.yml
@@ -2,3 +2,7 @@ services:
   plugin.manager.webform_product:
     class: Drupal\webform_product\WebformProductPluginManager
     parent: default_plugin_manager
+  webform_product.order_subscriber:
+    class: Drupal\webform_product\EventSubscriber\OrderEventSubscriber
+    tags:
+    - { name: event_subscriber }


### PR DESCRIPTION
Using the 'default' types in Commerce is not always desirable.
Therefore a Webform Handler could be very useful.

**This is still in progress, and not ready to merge.**

ToDo:
1. Allow to redirect to Cart instead of Checkout Flow
2. Add more configuration
3. Fix the multiple todo's in code
4. Cleanup old code
5. Set 'secure token' option in Webform config when saving the handler

New features:
1. Webform handler for configuration per webform
2. Post validation event for submitting the submission on early leave within the offsite payment provider
3. Optional selection of a calculated order item, by using a Twig computed field

Diagram to explain some inner workings:
![webform_product_diagram](https://user-images.githubusercontent.com/16167082/47505768-0f08bb00-d86f-11e8-8256-b81b91d191fd.png)

Feedback is always welcome!

Thanks to @Sutharsan for feedback and contributions to the code.

